### PR TITLE
Adding GitHub Action workflow.

### DIFF
--- a/.github/workflows/build-go.yaml
+++ b/.github/workflows/build-go.yaml
@@ -1,0 +1,29 @@
+# .github/workflows/release.yaml
+
+on:
+    release:
+        types: [created]
+
+permissions:
+    contents: write
+    packages: write
+
+jobs:
+  releases-matrix:
+    name: Release Go Binary
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        goos: [linux, windows]
+        goarch: [amd64, arm64]
+        exclude:
+          - goarch: arm64
+            goos: windows
+    steps:
+    - uses: actions/checkout@v4
+    - uses: wangyoucao577/go-release-action@v1
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        goos: ${{ matrix.goos }}
+        goarch: ${{ matrix.goarch }}
+        extra_files: LICENSE README.md


### PR DESCRIPTION
Based on "Go Release Binaries" (https://github.com/marketplace/actions/go-release-binaries).